### PR TITLE
Add support for hubot-auth

### DIFF
--- a/src/scripts/deploy.js
+++ b/src/scripts/deploy.js
@@ -34,10 +34,28 @@ var apiRequest = function(msg, path, method, data) {
     });
 };
 
-var deployRevision = function(msg) {
+var isAuthorized = function(robot, user, app, ref, env, action) {
+    if (robot.auth.hasRole === undefined) {
+        return true;  // hubot-auth not installed
+    };
+    // todo: add support for more granular permissions
+    return robot.auth.hasRole(user,'freight:admin');
+};
+
+var authError = function(msg) {
+    msg.reply("Sorry, I won't take any order from you.");
+    console.error('Freight: user %s is not authorized to perform this aciton', msg.envelope.user);
+};
+
+var deployRevision = function(msg, robot) {
   var app = msg.match[1];
   var ref = msg.match[3];
   var env = msg.match[5];
+
+  if (!isAuthorized(robot, msg.envelope.user, app, ref, env, 'deploy')) {
+    authError(msg);
+    return;
+  };
 
   var data = {
     ref: ref || undefined,
@@ -49,9 +67,14 @@ var deployRevision = function(msg) {
   apiRequest(msg, "/tasks/", "POST", data);
 };
 
-var rollbackDeploy = function(msg) {
+var rollbackDeploy = function(msg, robot) {
   var app = msg.match[1];
   var env = msg.match[3];
+
+  if (!isAuthorized(robot, msg.envelope.user, app, null, env, 'rollback')) {
+    authError(msg);
+    return;
+  };
 
   var data = {
     ref: ':previous',
@@ -63,10 +86,15 @@ var rollbackDeploy = function(msg) {
   apiRequest(msg, "/tasks/", "POST", data);
 };
 
-var cancelDeploy = function(msg) {
+var cancelDeploy = function(msg, robot) {
   var app = msg.match[1];
   var env = msg.match[2];
   var number = msg.match[3];
+
+  if (!isAuthorized(robot, msg.envelope.user, app, null, env, 'cancel')) {
+    authError(msg);
+    return;
+  };
 
   var data = {
     status: "cancelled"
@@ -77,14 +105,14 @@ var cancelDeploy = function(msg) {
 
 module.exports = function(robot) {
   robot.respond(/deploy ([^\s\:\/]+)(\:([^\s]+))?( to ([^\s]+))?/i, function(msg) {
-    deployRevision(msg);
+    deployRevision(msg, robot);
   });
 
   robot.respond(/rollback ([^\/]+)(\/([^\s]+))?/i, function(msg) {
-    rollbackDeploy(msg);
+    rollbackDeploy(msg, robot);
   });
 
   robot.respond(/cancel ([^\/]+)\/([^#]+)#(\d+)/i, function(msg) {
-    cancelDeploy(msg);
+    cancelDeploy(msg, robot);
   });
 };


### PR DESCRIPTION
This will make sure that, if https://github.com/hubot-scripts/hubot-auth plugin is installed, only users with the `freight:admin` role will be allowed to send deploy commands to Freight (I wouldn't allow non-tech people hanging around on slack to run deployments..).

Extra arguments to `isAuthorized()` are meant to allow deeper permission checking, eg. per-app or per-environment permissions (this comes in handy in larger organizations).

Cheers!
